### PR TITLE
Fix Overridden Icons, Add dense layout and read-only option

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm"
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm i -g homey"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
 	"id": "ady.enhanced_device_widget",
-	"version": "1.0.6",
+	"version": "1.1.0",
 	"compatibility": ">=12.1.0",
 	"sdk": 3,
 	"brandColor": "#FF7D4B",

--- a/app.js
+++ b/app.js
@@ -67,13 +67,18 @@ class MyApp extends Homey.App
 					// Device not found
 					return null;
 				}
+				let iconURI = device?.iconObj?.url;
+				if (device.iconOverride)
+				{
+					iconURI = `https://my.homey.app/img/devices/${device.iconOverride}.svg`;
+				}
 
 				if (this.logLevel > 0)
 				{
 					this.updateLog(`Device image URL for ${deviceId}:\n${JSON.stringify(device.iconObj, null, 2)}`);
 				}
 
-				return device.iconObj?.url ? `${device.iconObj.url}` : null;
+				return iconURI;
 			}
 			catch (e)
 			{

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "ady.enhanced_device_widget",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "compatibility": ">=12.1.0",
   "sdk": 3,
   "brandColor": "#FF7D4B",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "ady.enhanced_device_widget",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "compatibility": ">=12.1.0",
   "sdk": 3,
   "brandColor": "#FF7D4B",
@@ -116,6 +116,22 @@
             "pt": "Configuração em tempo de execução ativada",
             "pl": "Włączona konfiguracja czasu wykonania",
             "ko": "활성화 된 실행 시간 구성"
+          }
+        },
+        {
+          "id": "readonly",
+          "type": "checkbox",
+          "value": false,
+          "title": {
+            "en": "Read only?"
+          }
+        },
+        {
+          "id": "dense",
+          "type": "checkbox",
+          "value": false,
+          "title": {
+            "en": "Dense Layout?"
           }
         }
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"homey-api": "^3.4.18"
 			},
 			"devDependencies": {
-				"@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.7",
+				"@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.9",
 				"eslint": "^8.15.0",
 				"eslint-config-athom": "^3.1.3"
 			},
@@ -153,10 +153,11 @@
 		},
 		"node_modules/@types/homey": {
 			"name": "homey-apps-sdk-v3-types",
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.7.tgz",
-			"integrity": "sha512-E4Vcfew9/snrJkyog2Z+0xTZCakc55VM0j89jR5z6dkDB0HZdiU2D3kt2R+x19Wt1IFBLaYiBEztASPNCYXJuw==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.9.tgz",
+			"integrity": "sha512-K4h2D2UwDFED9ML5rLIGJxgOV3FjlQYcrOjwgbJ3v5N38Iz7fvAzZlkf1XEPIClPVzsSxnOvasFs9Jw6cgzs+g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@types/node": "^14.14.20"
 			}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"lint": "eslint --ext .js,.ts --ignore-path .gitignore ."
 	},
 	"devDependencies": {
-		"@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.7",
+		"@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.9",
 		"eslint": "^8.15.0",
 		"eslint-config-athom": "^3.1.3"
 	},

--- a/widgets/enhanced-device/public/extraStyles.css
+++ b/widgets/enhanced-device/public/extraStyles.css
@@ -1,17 +1,35 @@
 .alignleft {
 	float: left;
-	margin-top: 15px;
 	margin-bottom: 0px;
-	height: 25px;
 	align-items: center;
 }
 
 .alignright {
 	float: right;
-	margin-top: 15px;
 	margin-bottom: 0px;
-	height: 25px;
 	align-items: center;
+}
+
+.alignleft[dense="false"] {
+	margin-top: 15px;
+	height: 25px;
+}
+
+.alignleft[dense="true"] {
+	line-height: 24px;
+}
+
+.alignright[dense="false"] {
+	margin-top: 15px;
+	height: 25px;
+}
+
+.alignright[dense="true"] {
+	line-height: 24px;
+}
+
+#capabilitiesSection[dense="true"] {
+	padding-top: 6px;
 }
 
 /* The switch - the box around the slider */

--- a/widgets/enhanced-device/public/index.html
+++ b/widgets/enhanced-device/public/index.html
@@ -33,11 +33,16 @@
 			// View the settings the user provided if your widget has settings.
 			const settings = Homey.getSettings();
 			document.getElementById('deviceName').innerHTML = settings.devices.name;
-			document.getElementById('deviceIcon').src = settings.devices.iconObj.url;
+
+			if (settings.devices.iconOverride) {
+				// haven't found another trick for the default icons yet
+				document.getElementById('deviceIcon').src = 'https://my.homey.app/img/devices/' + settings.devices.iconOverride + '.svg';
+			} else {
+				document.getElementById('deviceIcon').src = settings.devices.iconObj.url;
+			}
 
 			document.getElementById('enableEdit').style.display = settings.enableConfiguration ? 'flex' : 'none';
 			editEnabled = settings.enableConfiguration;
-			// editMode = editEnabled;
 			document.getElementById('editMode').checked = editMode;
 
 			Homey.api('GET', `/?disabledCapabilities=${widgetId}`, {})
@@ -95,6 +100,9 @@
 			// View the settings the user provided if your widget has settings.
 			const settings = Homey.getSettings();
 
+			const denseLayout = settings.dense;
+			let heightAdd = denseLayout ? 24 : 40;
+
 			// Fetch something from your app.
 			Homey.api('GET', `/?deviceId=${settings.devices.id}&disabledCapabilities=${disabledCapabilities ? JSON.stringify(disabledCapabilities) : null}`, {})
 				.then((result) =>
@@ -129,15 +137,15 @@
 													</p>`;
 							}
 
-							if (capability.setable === true)
+							if (capability.setable === true && !settings.readonly)
 							{
 								if ((capability.type === "boolean") && capability.getable)
 								{
-									height += 40;
+									height += heightAdd;
 
 									// create a switch for boolean capabilities
-									html += `<p class="alignleft homey-font-size-default"> ${capability.title}</p>
-												<p class="alignright homey-font-size-default">
+									html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p>
+												<p class="alignright homey-font-size-default" dense="${denseLayout}">
 													<b>
 														<span>
 															<label class="switch">
@@ -151,11 +159,11 @@
 								}
 								else if (capability.type === "boolean")
 								{
-									height += 40;
+									height += heightAdd;
 
 									// Create a push button
-									html += `<p class="alignleft homey-font-size-default"> ${capability.title}</p>
-												<p class="alignright homey-font-size-default">
+									html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p>
+												<p class="alignright homey-font-size-default" dense="${denseLayout}">
 													<b>
 														<span>
 															<button class="button" id="${capability.id}" onclick="buttonPressed('${settings.devices.id}', '${capability.id}')">
@@ -168,10 +176,10 @@
 								else if (capability.type === "number")
 								{
 									// Allow extra space for sliders
-									height += 60;
+									height += heightAdd + (denseLayout ? 10 : 20);
 
 									// create a slider for number capabilities
-									html += `<p class="alignleft homey-font-size-default"> ${capability.title}</p><p class="alignright homey-font-size-default"><b> <span id="${capability.id}">${(capability.id === 'dim') || (capability.id == 'windowcoverings_set') ? capability.value * 100 : capability.value}</span> </b> ${capability.units ? capability.units : ''}</p>
+									html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p><p class="alignright homey-font-size-default" dense="${denseLayout}"><b> <span id="${capability.id}">${(capability.id === 'dim') || (capability.id == 'windowcoverings_set') ? capability.value * 100 : capability.value}</span> </b> ${capability.units ? capability.units : ''}</p>
 												<div style="clear: both;"></div>
 												<p class="homey-font-size-default" style="padding-top:0px; padding-bottom:5px">
 												<input
@@ -193,16 +201,22 @@
 								}
 								else
 								{
-									height += 40;
+									height += heightAdd;
 
-									html += `<p class="alignleft homey-font-size-default"> ${capability.title}</p> <p class="alignright homey-font-size-default"><b> <span id="${capability.id}"> ${capability.value}</span> </b> ${capability.units ? capability.units : ''}</p>`;
+									html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p> <p class="alignright homey-font-size-default" dense="${denseLayout}"><b> <span id="${capability.id}"> ${capability.value}</span> </b> ${capability.units ? capability.units : ''}</p>`;
 								}
 							}
 							else
 							{
-								height += 40;
+								height += heightAdd;
 
-								html += `<p class="alignleft homey-font-size-default"> ${capability.title}</p> <p class="alignright homey-font-size-default"><b> <span id="${capability.id}"> ${capability.value}</span> </b> ${capability.units ? capability.units : ''}</p>`;
+								let value = capability.value;								
+								if (capability.type == "enum") {
+									let e = capability.values.find((v) => v.id == value);
+									value = e ? e.title : value;
+								}
+
+								html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p> <p class="alignright homey-font-size-default" dense="${denseLayout}"><b> <span id="${capability.id}"> ${value}</span> </b> ${capability.units ? capability.units : ''}</p>`;
 							}
 
 							html += `</div >
@@ -213,6 +227,8 @@
 					}
 
 					document.getElementById('capabilitiesSection').innerHTML = html;
+					document.getElementById('capabilitiesSection').setAttribute("dense", denseLayout);
+
 					Homey.setHeight(height);
 
 					console.log(result);

--- a/widgets/enhanced-device/public/index.html
+++ b/widgets/enhanced-device/public/index.html
@@ -182,12 +182,12 @@
 								else if (capability.type === "number")
 								{
 									// Allow extra space for sliders
-									height += heightAdd + (denseLayout ? 45 : 55);
+									height += heightAdd + (denseLayout ? 30 : 15);
 
 									// create a slider for number capabilities
 									html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p><p class="alignright homey-font-size-default" dense="${denseLayout}"><b> <span id="${capability.id}">${(capability.id === 'dim') || (capability.id == 'windowcoverings_set') ? capability.value * 100 : capability.value}</span> </b> ${capability.units ? capability.units : ''}</p>
 												<div style="clear: both;"></div>
-												<p class="homey-font-size-default" style="padding-top:0px; padding-bottom:5px">
+												<p class="homey-font-size-default" style="${denseLayout ? "padding-top:5px; padding-bottom:15px" : "padding-top:0px; padding-bottom:5px"}">
 												<input
 													id="${capability.id}_slide"
 													type="range"
@@ -210,8 +210,8 @@
 									height += heightAdd;
 
 									// Create a drop list for enum capabilities
-									html += `<p class="alignleft homey-font-size-default"> ${capability.title}</p>
-												<p class="alignright homey-font-size-default dense="${denseLayout}"">
+									html += `<p class="alignleft homey-font-size-default" dense="${denseLayout}"> ${capability.title}</p>
+												<p class="alignright homey-font-size-default" dense="${denseLayout}">
 													<b>
 														<span>
 															<select class="select" id="${capability.id}" onchange="dropListChanged('${settings.devices.id}', '${capability.id}')">`
@@ -249,7 +249,7 @@
 									</div>`;
 
 						}
-//					}
+					// }
 					}
 
 					document.getElementById('capabilitiesSection').innerHTML = html;

--- a/widgets/enhanced-device/widget.compose.json
+++ b/widgets/enhanced-device/widget.compose.json
@@ -33,6 +33,22 @@
 				"pl": "Włączona konfiguracja czasu wykonania",
 				"ko": "활성화 된 실행 시간 구성"
 			}
+		},
+		{
+			"id": "readonly",
+			"type": "checkbox",
+			"value": false,
+			"title": {
+				"en": "Read only?"
+			}
+		},
+		{
+			"id": "dense",
+			"type": "checkbox",
+			"value": false,
+			"title": {
+				"en": "Dense Layout?"
+			}
 		}
 	],
 	"api": {


### PR DESCRIPTION
## Fixes
- Correct displaying of overridden icons. Stil a hack, but haven't found a better solution
- Enum display now shows transposed, translated title

## Added
- Read-only option
- Dense layout option that matches "my.homey.app"
- DEV container configuration for Visual Studio Code
